### PR TITLE
Fix `RedisCacheStore` INCR/DECR for Redis < v7.0.0

### DIFF
--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -141,6 +141,8 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @cache = lookup_store(expires_in: 60)
       # @cache.logger = Logger.new($stdout)  # For test debugging
 
+      @cache_no_ttl = lookup_store
+
       # For LocalCacheBehavior tests
       @peek = lookup_store(expires_in: 60)
     end
@@ -193,6 +195,23 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    def test_increment
+      # existing key
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
+      @cache_no_ttl.increment "jar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:jar").to_i == 11
+        assert r.ttl("#{@namespace}:jar") < 0
+      end
+
+      # new key
+      @cache_no_ttl.increment "kar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:kar").to_i == 1
+        assert r.ttl("#{@namespace}:kar") < 0
+      end
+    end
+
     def test_increment_expires_in
       @cache.increment "foo", 1, expires_in: 60
       redis_backend do |r|
@@ -208,10 +227,27 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
 
       # key exist but not have expire
-      redis_backend { |r| r.set "#{@namespace}:dar", 10 }
-      @cache.increment "dar", 1, expires_in: 60
-      redis_backend do |r|
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
+      @cache_no_ttl.increment "dar", 1, expires_in: 60
+      redis_backend(@cache_no_ttl) do |r|
         assert r.ttl("#{@namespace}:dar") > 0
+      end
+    end
+
+    def test_decrement
+      # existing key
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
+      @cache_no_ttl.decrement "jar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:jar").to_i == 9
+        assert r.ttl("#{@namespace}:jar") < 0
+      end
+
+      # new key
+      @cache_no_ttl.decrement "kar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:kar").to_i == -1
+        assert r.ttl("#{@namespace}:kar") < 0
       end
     end
 
@@ -230,9 +266,9 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
 
       # key exist but not have expire
-      redis_backend { |r| r.set "#{@namespace}:dar", 10 }
-      @cache.decrement "dar", 1, expires_in: 60
-      redis_backend do |r|
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
+      @cache_no_ttl.decrement "dar", 1, expires_in: 60
+      redis_backend(@cache_no_ttl) do |r|
         assert r.ttl("#{@namespace}:dar") > 0
       end
     end
@@ -252,8 +288,8 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
-    def redis_backend
-      @cache.redis.with do |r|
+    def redis_backend(cache = @cache)
+      cache.redis.with do |r|
         yield r if block_given?
         return r
       end


### PR DESCRIPTION
This commit fixes a discrepancy in the behavior of the `#increment` and `#decrement` methods in `RedisCacheStore` when used with Redis versions less than 7.0.0. The existing condition `count != amount` prevented setting the Time-To-Live (TTL) for keys that were equal to the increment/decrement amount after the `INCRBY`/`DECRBY` operation. This occurs when incrementing a non-existent key by `1`, for example.

Using Redis pipelining, we minimize the network overhead incurred by checking for existing TTLs. It decouples the TTL operations from the increment/decrement operation, allowing the TTL to be set correctly regardless of the resulting value from the `INCRBY`/`DECRBY`.

New tests have been added to verify the correct behavior of `#increment` and `#decrement` methods, specifically when the `expires_in` option is not used. Using a separate cache store instance (`@cache_no_ttl`), these tests ensure that keys are correctly incremented or decremented and that their TTL remains unset.

### Motivation / Background

We noticed the test failures on the `main` branch for Redis versions `<7.0.0`. The culprit was a change introduced in #45711, where a condition was added that prevents the TTL from being set. This happens when a key without TTL is incremented or decremented and the resulting value equals the amount it is incremented/decremented by. 

This breaks the expected behavior of setting the TTL on the first call to increment when `:expires_in` is provided, particularly when the operation results in the key's value set to `1`. This happens often in rate limiting scenarios when the key is either initialized to `0` by the application, or by Redis, before being incremented to `1`.

### Detail

This PR modifies the `change_counter` method in `RedisCacheStore`, removing the `count != amount` check. 

With this fix, TTL is set upon the first increment operation, irrespective of the counter's value, aligning the behavior outlined in the specs.

For example:

https://github.com/rails/rails/blob/f11c6513fe36821057c46cbccc67bb041c157454/activesupport/test/cache/stores/redis_cache_store_test.rb#L196-L201

Because the `foo` key is not defined, [...it is set to 0 before performing the operation...](https://redis.io/commands/incr/) by Redis. When it performs increment, the value will be `1`. Once the value is `1`, `#change_counter` will fail to issue `EXPIRE`.

https://github.com/rails/rails/blob/f11c6513fe36821057c46cbccc67bb041c157454/activesupport/lib/active_support/cache/redis_cache_store.rb#L447-L450

Here, `count` is `1` and `amount` is `1`, making the `count != amount` condition `false`.

In the original code before the patch, the TTL was set in the first call to `#increment`, given that the `:expires_in` option was provided. 

https://github.com/rails/rails/blob/6bfc637659248df5d6719a86d2981b52662d9b50/activesupport/lib/active_support/cache/redis_cache_store.rb#L239-L242

Here, the TTL was set within a `tap` block that executes after the increment operation, irrespective of the counter's value.

### Additional Details

<details>
  <summary> Test Failures </summary>

```shell
$ bin/test test/cache/stores/redis_cache_store_test.rb --defer-output

Running 626 tests in parallel using 6 processes
Run options: --defer-output --seed 53989

# Running:

...................................................................................................................................................................S..........................................................................................................F........................................F........................................................................................................................................S.........................................................................................................F.......................................F...............................

Finished in 4.126056s, 151.7187 runs/s, 579.9728 assertions/s.

  1) Failure:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreCommonBehaviorTest#test_decrement_expires_in [/workspaces/rails/activesupport/test/cache/stores/redis_cache_store_test.rb:222]:
Expected false to be truthy.

  2) Failure:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreCommonBehaviorTest#test_increment_expires_in [/workspaces/rails/activesupport/test/cache/stores/redis_cache_store_test.rb:200]:
Expected false to be truthy.

  3) Failure:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreWithDistributedRedisTest#test_decrement_expires_in [/workspaces/rails/activesupport/test/cache/stores/redis_cache_store_test.rb:222]:
Expected false to be truthy.

  4) Failure:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreWithDistributedRedisTest#test_increment_expires_in [/workspaces/rails/activesupport/test/cache/stores/redis_cache_store_test.rb:200]:
Expected false to be truthy.

626 runs, 2393 assertions, 4 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.

Failed tests:

bin/test test/cache/stores/redis_cache_store_test.rb:218
bin/test test/cache/stores/redis_cache_store_test.rb:196
bin/test test/cache/stores/redis_cache_store_test.rb:218
bin/test test/cache/stores/redis_cache_store_test.rb:196

```
</details>

<details>
  <summary>Test Infrastructure Setup via Docker Compose</summary>


```diff
version: '3'

services:
  rails:
    build:
      context: ..
      dockerfile: .devcontainer/Dockerfile

    volumes:
      - ../..:/workspaces:cached

    # Overrides default command so things don't shut down after the process ends.
    command: sleep infinity

    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
    networks:
      - default

    depends_on:
      - postgres
      - mariadb
      - redis
      - memcached

    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
    # (Adding the "ports" property to this file will not forward from a Codespace.)

  postgres:
    image: postgres:latest
    restart: unless-stopped
    networks:
      - default
    volumes:
      - postgres-data:/var/lib/postgresql/data
    environment:
      POSTGRES_USER: postgres
      POSTGRES_DB: postgres
      POSTGRES_PASSWORD: postgres

  mariadb:
    image: mariadb:latest
    restart: unless-stopped
    networks:
      - default
    volumes:
      - mariadb-data:/var/lib/mysql
    environment:
      MARIADB_ROOT_PASSWORD: root

  redis:
-    image: redis:latest
+    image: redis:6.2
    restart: unless-stopped
    networks:
      - default
    volumes:
      - redis-data:/data

  memcached:
    image: memcached:latest
    restart: unless-stopped
    command: ["-m", "1024"]
    networks:
      - default

networks:
  default:

volumes:
  postgres-data:
  mariadb-data:
  redis-data:
```

</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
